### PR TITLE
Ensure that the expiration table is initialized properly, otherwise the ...

### DIFF
--- a/src/main/clojure/clojure/core/cache.clj
+++ b/src/main/clojure/clojure/core/cache.clj
@@ -492,7 +492,7 @@
   [ttl base]
   {:pre [(number? ttl) (<= 0 ttl)
          (map? base)]}
-  (TTLCache. base {} ttl))
+  (clojure.core.cache/seed (TTLCache. {} {} ttl) base))
 
 (defn lu-cache-factory
   "Returns an LU cache with the cache and usage-table initialied to `base`."


### PR DESCRIPTION
...base entries live forever
