### PR TITLE
Obey limit when adding element to fifo and check q count in fifo factory post condition

### DIFF
--- a/src/main/clojure/clojure/core/cache.clj
+++ b/src/main/clojure/clojure/core/cache.clj
@@ -155,10 +155,13 @@
   (hit [this item]
     this)
   (miss [_ item result]
-    (let [k (peek q)]
-      (FIFOCache. (-> cache (dissoc k) (assoc item result))
-                  (-> q pop (conj item))
-                  limit)))
+        (let [[cache q] (if (>= (count cache) limit)
+                          (let [k (peek q)]
+                            [(dissoc cache k) (pop q)])
+                          [cache q])]
+          (FIFOCache. (assoc cache item result)
+                      (conj q item)
+                      limit)))
   (evict [this key]
     (let [v (get cache key ::miss)]
       (if (= v ::miss)
@@ -566,7 +569,7 @@
   [base & {threshold :threshold :or {threshold 32}}]
   {:pre [(number? threshold) (< 0 threshold)
          (map? base)]
-   :post [(== threshold (count %))]}
+   :post [(== threshold (count (.q ^FIFOCache %)))]}
   (clojure.core.cache/seed (FIFOCache. {} clojure.lang.PersistentQueue/EMPTY threshold) base))
 
 (defn lru-cache-factory


### PR DESCRIPTION
I think there are two issues with the FIFOCache.

1) fifo-cache-factory checks the postcondition `clojure (= threshold (count %))` which fails if threshold is not equal `clojure (count base)`

2) The FIFOCache behaviour is not quite right. After removing an element (e.g. by pruning) the limit will never be reached again when inserting elements. E.g.

``` clojure
clojure.core.cache>  (def C (fifo-cache-factory {:a 1 :b 2} :threshold 2))
clojure.core.cache> (-> C (dissoc :a) (assoc :a 1))
{:a 1}
```
