### PR TITLE
Bugfix on has? in TTL cache

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
              :1.5   {:dependencies [[org.clojure/clojure "1.5.0"]]}
              :1.5.1 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6   {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
+             :1.7   {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :dev   {:plugins [[com.jakemccrary/lein-test-refresh "0.21.1"]]}}
   :plugins [[lein-swank "1.4.4"]
             [lein-marginalia "0.7.1"]]
   :repositories {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}

--- a/src/main/clojure/clojure/core/cache.clj
+++ b/src/main/clojure/clojure/core/cache.clj
@@ -266,9 +266,10 @@
       not-found))
   (has? [_ item]
     (let [t (get ttl item (- ttl-ms))]
-      (< (- (System/currentTimeMillis)
-            t)
-         ttl-ms)))
+      (and (< (- (System/currentTimeMillis)
+                 t)
+              ttl-ms)
+           (contains? cache item))))
   (hit [this item] this)
   (miss [this item result]
     (let [now  (System/currentTimeMillis)

--- a/src/test/clojure/clojure/core/cache/tests.clj
+++ b/src/test/clojure/clojure/core/cache/tests.clj
@@ -223,7 +223,19 @@
            {:c 3} (-> C (assoc :a 1) (assoc :b 2) (sleepy 700) (assoc :c 3) .cache))))
   (testing "TTL cache does not return a value that has expired."
     (let [C (ttl-cache-factory {} :ttl 500)]
-      (is (nil? (-> C (assoc :a 1) (sleepy 700) (lookup :a)))))))
+      (is (nil? (-> C (assoc :a 1) (sleepy 700) (lookup :a))))))
+
+  (testing "TTL cache checks both composed cache for a key and the TTL-ness of a key"
+    (let [single-item-cache (lru-cache-factory {} :threshold 1)
+          one-day           (* 1000 60 60 24)
+          one-day-cache     (ttl-cache-factory single-item-cache :ttl one-day)]
+      (is
+        (false?
+          (->
+            one-day-cache
+            (miss "a" "a-value")
+            (miss "b" "b-value")
+            (has? "a")))))))
 
 (deftest test-lu-cache-ilookup
   (testing "that the LUCache can lookup via keywords"


### PR DESCRIPTION
If a TTL cache composes another cache, the presence of a key has to be checked both against the TTL list and the composed cache. Otherwise, the TTL cache could say that an item is still present (because the TTL has not yet expired), but the item is removed from the composed cache. In such a case, a user will get a true from has? but a nil from lookup (because the key is no longer present in the composed cache). 